### PR TITLE
Adds a report spam button to each post

### DIFF
--- a/ld-spam-remover.js
+++ b/ld-spam-remover.js
@@ -1,7 +1,8 @@
 // ==UserScript==
 // @name     LD Spam Remover
 // @version  1
-// @grant    none
+// @grant    GM_addStyle
+// @description none
 // @match        https://ldjam.com/
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=ldjam.com
 // ==/UserScript==
@@ -69,11 +70,24 @@ const loadUserData = function (name) {
     httpRequest.send();
 }
 
+let blacklistUsers = [
+    'deden-benoma',
+    'heri',
+    'jack-leo',
+    'boardbandinternetprovider',
+    'kidav52410',
+    'laura5',
+    'tandiv20154'
+];
+
+blacklistUsers = blacklistUsers.concat(JSON.parse(localStorage.getItem("blacklistUsers")));
+
 // -1 = unknown
 //  0 = spam
 //  1 = not spam
 const getSpamStatus = function (index, body, name) {
     loadUserData(name);
+    if (blacklistUsers.includes(name)) return 0;
     if (users[name].gameCount > 0) return 1;
     // No game published
     if (users[name].gameCount === 0) {
@@ -126,6 +140,30 @@ const clean = function () {
             }
 
         }
+
+        if (document.getElementById(`${name + i}`) == null) {
+            var zNode = document.createElement('div');
+            zNode.innerHTML = `<button id=${name + i} type="button" class="spam-button">`
+                            + 'Report Spam</button>'
+                            ;
+            zNode.setAttribute('id', `container-${name + i}`);
+            elements[i].append(zNode);
+
+            // Activate the newly added button.
+            if (document.getElementById(`${name + i}`) != null) {
+                document.getElementById(`${name + i}`).addEventListener (
+                    "click", ButtonClickAction, false
+                );
+            }
+
+            function ButtonClickAction (zEvent) {
+                var zNode = document.createElement('p');
+                zNode.innerHTML = 'Spam Reported!';
+                document.getElementById(`container-${name + i}`).appendChild(zNode);
+                blacklistUsers.push(name);
+                localStorage.setItem("blacklistUsers", JSON.stringify(blacklistUsers));
+            }
+        }
     }
 
     if (countRemoved > 0) {
@@ -134,6 +172,7 @@ const clean = function () {
         info.textContent = `LD Spam Remover: ${countSpamsRemovedLately} spams removed`;
         displayInfoTimer = 5;
     }
+
 }
 
 if (window.location.hostname === "ldjam.com") {
@@ -150,3 +189,24 @@ if (window.location.hostname === "ldjam.com") {
     document.body.appendChild(info);
     setInterval(clean, 1000);
 }
+
+//--- Style our newly added elements using CSS.
+GM_addStyle ( `
+    .spam-button {
+        position: relative;
+        width: auto;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        background: #b9c4d0;
+        display: flex;
+        line-height: 2.5rem;
+        height: 2.5rem;
+        min-width: 1.25rem;
+        color: white;
+        font-size: 1em;
+        font-weight: bold;
+        height: 45px;
+        border: 1px solid white;
+        cursor: pointer;
+    }
+` );

--- a/ld-spam-remover.js
+++ b/ld-spam-remover.js
@@ -80,7 +80,15 @@ let blacklistUsers = [
     'tandiv20154'
 ];
 
-blacklistUsers = blacklistUsers.concat(JSON.parse(localStorage.getItem("blacklistUsers")));
+blacklistUsers = blacklistUsers.concat(JSON.parse(localStorage.getItem("blacklistUsers")));/*[
+    'deden-benoma',
+    'heri',
+    'jack-leo',
+    'boardbandinternetprovider',
+    'kidav52410',
+    'laura5',
+    'tandiv20154'
+]*/
 
 // -1 = unknown
 //  0 = spam
@@ -143,6 +151,7 @@ const clean = function () {
 
         if (document.getElementById(`${name + i}`) == null) {
             var zNode = document.createElement('div');
+            zNode.className = 'spam-btn-container';
             zNode.innerHTML = `<button id=${name + i} type="button" class="spam-button">`
                             + 'Report Spam</button>'
                             ;
@@ -162,6 +171,7 @@ const clean = function () {
                 document.getElementById(`container-${name + i}`).appendChild(zNode);
                 blacklistUsers.push(name);
                 localStorage.setItem("blacklistUsers", JSON.stringify(blacklistUsers));
+                console.table(blacklistUsers);
             }
         }
     }
@@ -192,6 +202,12 @@ if (window.location.hostname === "ldjam.com") {
 
 //--- Style our newly added elements using CSS.
 GM_addStyle ( `
+    .spam-btn-container {
+        position: absolute;
+        margin-left: 68px;
+        margin-top: -42px;
+    }
+
     .spam-button {
         position: relative;
         width: auto;
@@ -205,8 +221,12 @@ GM_addStyle ( `
         color: white;
         font-size: 1em;
         font-weight: bold;
-        height: 45px;
-        border: 1px solid white;
+        height: 42px;
+        border: none;
         cursor: pointer;
+    }
+
+    .spam-button:hover {
+        background-color: #ed5533;
     }
 ` );

--- a/ld-spam-remover.js
+++ b/ld-spam-remover.js
@@ -70,25 +70,11 @@ const loadUserData = function (name) {
     httpRequest.send();
 }
 
-let blacklistUsers = [
-    'deden-benoma',
-    'heri',
-    'jack-leo',
-    'boardbandinternetprovider',
-    'kidav52410',
-    'laura5',
-    'tandiv20154'
-];
+let blacklistUsers = [];
 
-blacklistUsers = blacklistUsers.concat(JSON.parse(localStorage.getItem("blacklistUsers")));/*[
-    'deden-benoma',
-    'heri',
-    'jack-leo',
-    'boardbandinternetprovider',
-    'kidav52410',
-    'laura5',
-    'tandiv20154'
-]*/
+if (localStorage.getItem("blacklistUsers") != null) {
+    blacklistUsers = blacklistUsers.concat(JSON.parse(localStorage.getItem("blacklistUsers")))
+}
 
 // -1 = unknown
 //  0 = spam
@@ -150,13 +136,12 @@ const clean = function () {
         }
 
         if (document.getElementById(`${name + i}`) == null) {
-            var zNode = document.createElement('div');
-            zNode.className = 'spam-btn-container';
-            zNode.innerHTML = `<button id=${name + i} type="button" class="spam-button">`
-                            + 'Report Spam</button>'
-                            ;
-            zNode.setAttribute('id', `container-${name + i}`);
-            elements[i].append(zNode);
+            let spamContainerEl = document.createElement('div');
+            spamContainerEl.className = 'spam-btn-container';
+            spamContainerEl.innerHTML = `<button id=${name + i} type="button" class="spam-button">`
+                                      + 'Report Spam</button>';
+            spamContainerEl.setAttribute('id', `container-${name + i}`);
+            elements[i].append(spamContainerEl);
 
             // Activate the newly added button.
             if (document.getElementById(`${name + i}`) != null) {
@@ -165,13 +150,12 @@ const clean = function () {
                 );
             }
 
-            function ButtonClickAction (zEvent) {
-                var zNode = document.createElement('p');
-                zNode.innerHTML = 'Spam Reported!';
-                document.getElementById(`container-${name + i}`).appendChild(zNode);
+            function ButtonClickAction (event) {
+                let messageEl = document.createElement('p');
+                messageEl.innerHTML = 'Spam Reported!';
+                document.getElementById(`container-${name + i}`).appendChild(messageEl);
                 blacklistUsers.push(name);
                 localStorage.setItem("blacklistUsers", JSON.stringify(blacklistUsers));
-                console.table(blacklistUsers);
             }
         }
     }


### PR DESCRIPTION
If any spam makes it through the regular filters, this appends a "Report Spam" button that blacklists by username. The blacklist is just stored locally in the browser per user's device. I've only tested it on Chrome with Tampermonkey. Feel free to deny or alter this however best fits your awesome script and other's changes!